### PR TITLE
feat: add cover-image skill for article cover generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ build/
 
 
 openclaw/
+
+# Generated cover images
+cover-image/


### PR DESCRIPTION
## Summary
- Add `cover-image` skill for generating article cover images with 5 configurable dimensions (type, palette, rendering, text, mood)
- Supports cinematic (2.35:1), widescreen (16:9), and square (1:1) aspect ratios
- Includes 9 color palettes, 6 rendering styles, font/text/mood dimension references, and style presets
- Uses Qwen VL API for image generation with detailed prompt templates
- Add `cover-image/` to `.gitignore` to exclude generated output images

## Test plan
- [ ] Verify skill loads correctly with `/cover-image`
- [ ] Test cover image generation with different style presets
- [ ] Verify all reference files are accessible and correctly structured

🤖 Generated with [Claude Code](https://claude.com/claude-code)